### PR TITLE
Fix transition option index not written if equals to zero

### DIFF
--- a/core/src/main/java/studio/core/v1/model/Transition.java
+++ b/core/src/main/java/studio/core/v1/model/Transition.java
@@ -21,7 +21,7 @@ import lombok.Setter;
 @NoArgsConstructor
 @AllArgsConstructor
 @EqualsAndHashCode(exclude = "actionNode")
-@JsonInclude(Include.NON_DEFAULT)
+@JsonInclude(Include.NON_NULL)
 public class Transition {
 
     @JsonIdentityReference(alwaysAsId = true)


### PR DESCRIPTION
If the option index is 0, when writing the story.json, the option index will not be writting.
On the front side, the option index will be undefined and not 0, so it will be impossible to load the story.

Step to reproduce :
- Load a archive pack
- Transform it in FS pack
- Transforme the new FS pack in archive
- Load the new archive pack

A JS error will happen because getTransitionTargetNode() will return an optionPort null since 
In web-ui/javascript/src/utils/reader.js:381
`let optionPort = actionNode.optionsIn[transition.optionIndex];`
Will return null instead of the correct optionPort